### PR TITLE
Implement portal monitors on top of reworked portals.

### DIFF
--- a/src/agents/monitor/MonitorAgent.java
+++ b/src/agents/monitor/MonitorAgent.java
@@ -1,0 +1,42 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package agents.monitor;
+
+import agents.Message;
+import agents.MetaAgent;
+import agents.Portal;
+
+/**
+ *
+ * @author Aidan
+ */
+public class MonitorAgent extends Portal {
+
+    public MonitorAgent(int capacity, String name, Portal parent) {
+        super(capacity, name, parent);
+    }
+    
+    @Override
+    protected void executeOnSubAgent(String agent, Message message){
+        MetaAgent receive = getSubAgent(agent);
+        if (receive == null)
+        {
+            return;
+        }
+        
+        // Intercept and log messages for to direct children.
+        if (getChildren().containsValue(receive))
+            log(receive,message);
+        receive.addMessage(message);
+    }
+    
+    protected void log(MetaAgent target, Message message){
+        System.out.println("["+getName()+"] Intercepted message for " 
+                + target.getName()+": \n\t"+message);
+    }
+    
+    
+}

--- a/src/agents/monitor/MonitorMain.java
+++ b/src/agents/monitor/MonitorMain.java
@@ -1,0 +1,47 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package agents.monitor;
+
+import agents.Message;
+import agents.MetaAgent;
+import agents.Portal;
+import agents.impl.misc.LogMetaAgent;
+import agents.main.Showcase;
+import agents.util.EncodingUtil;
+
+/**
+ *
+ * @author Aidan
+ */
+public class MonitorMain implements Showcase {
+    
+    @Override
+    public void run(){
+        
+        Portal portalA = new Portal(10, "Portal A", null);
+        Portal portalB = new MonitorAgent(10, "Monitor B", portalA);
+        Portal portalC = new MonitorAgent(10, "Monitor C", portalB);
+        MetaAgent agentA = new LogMetaAgent(10, "Agent A", portalC);
+        
+        portalA.addChild(portalB);
+        portalB.addChild(portalC);
+        portalC.addChild(agentA);
+        
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException ex){}
+        
+        System.out.println("Sending message:");
+        portalA.addMessage(new Message
+            ("Agent A", EncodingUtil.StringToBytes("Hello World!"), "Portal A"));
+    }
+    
+    public static void main(String[] args) {
+        Showcase instance = new MonitorMain();
+        instance.run();
+    }
+    
+}


### PR DESCRIPTION
Portal monitors are specialised portals that can copy messages sent through them to an external source such as a GUI to track the structure of the program; etc.

This has been based off of the reworked portal behaviour as the current behaviour of master does not support this.